### PR TITLE
slight google api adjustment

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@
 
 
                 <script
-                    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAxqUekZhoGLhnTT57LPgjezVUPWx02C0M&callback=myMap"></script>
+                    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAxqUekZhoGLhnTT57LPgjezVUPWx02C0M"></script>
 
 
                 <script src="script.js"></script>


### PR DESCRIPTION
Ok, No big change here... we were just ignoring the error that was showing in the console about function myMap not being a function... it isn't.  I took it out of the api in index.html.  

the api used to read

    <script
                    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAxqUekZhoGLhnTT57LPgjezVUPWx02C0M&callback=myMap"></script>

now it reads

<script
                    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAxqUekZhoGLhnTT57LPgjezVUPWx02C0M"></script>

and the error is gone.